### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/user-service-ci.yml
+++ b/.github/workflows/user-service-ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/Agustiniano/DevOps-Lifecycle/security/code-scanning/1](https://github.com/Agustiniano/DevOps-Lifecycle/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block to the relevant job in the workflow, granting only the minimal privileges required. The only operation in this workflow that mandates elevated permissions is the `git push` step, which needs `contents: write`. The permissions block should be added to the `build-and-deploy` job definition (at the same level as `runs-on`). No imports or other file changes are needed, only inserting a permissions block. The edit should be made to `.github/workflows/user-service-ci.yml` before or immediately after `runs-on: ubuntu-latest`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
